### PR TITLE
fix: use supported codex help in postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,7 @@
   },
 
   // Run commands after the container is created
-  "postCreateCommand": "npm install -g codex-cli && echo '✅ Codex CLI installed successfully!' && codex --version",
+  "postCreateCommand": "npm install -g codex-cli && echo '✅ Codex CLI installed successfully!' && codex --help >/dev/null",
   
   // Configure tool-specific properties
   "customizations": {


### PR DESCRIPTION
## Summary
- replace unsupported `codex --version` with `codex --help` in devcontainer postCreateCommand to avoid startup failure

## Testing
- `npm install -g codex-cli && echo '✅ Codex CLI installed successfully!' && codex --help >/dev/null && echo done`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897d13cd258832093690d8bdb982d55