### PR TITLE
Silence legacy warnings in Codex CLI dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,8 +22,9 @@ RUN mkdir -p /home/node/.codex \
     && mkdir -p /home/node/.codex/tmp \
     && mkdir -p /workspace/.codex
 
-# Install Codex CLI globally
-RUN npm install -g codex-cli
+# Install Codex CLI globally and strip noisy legacy warnings
+RUN npm install -g codex-cli \
+    && sed -i "/Failed to load c\+\+ bson extension/d" $(npm root -g)/codex-cli/node_modules/bson/ext/index.js
 
 # Create a startup script
 RUN echo '#!/bin/bash\n\
@@ -31,7 +32,8 @@ echo "🚀 Codex CLI Development Container Ready!"\n\
 echo "Run \"codex\" to get started."\n\
 ' > /home/node/codex-setup.sh && chmod +x /home/node/codex-setup.sh
 
-# Set shell to zsh
+# Set shell to zsh and suppress Node warnings from outdated dependencies
+ENV NODE_NO_WARNINGS=1
 SHELL ["/bin/zsh", "-c"]
 
 # Expose ports for OAuth callbacks


### PR DESCRIPTION
## Summary
- Prevent bson native extension warning during `codex login`
- Suppress Node.js circular dependency warnings globally

## Testing
- `codex login`
- `NODE_NO_WARNINGS=1 codex login`


------
https://chatgpt.com/codex/tasks/task_e_6897d3d7dd288320a395789f96080529