### PR TITLE
fix: silence bson extension and node warnings for codex CLI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "Codex CLI Development Container",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bookworm",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
 
   // Features to add to the dev container
   "features": {
@@ -43,7 +45,7 @@
   },
 
   // Run commands after the container is created
-  "postCreateCommand": "npm install -g codex-cli && echo '✅ Codex CLI installed successfully!' && codex --help >/dev/null",
+  "postCreateCommand": "echo '✅ Codex CLI ready!' && codex --help >/dev/null",
   
   // Configure tool-specific properties
   "customizations": {


### PR DESCRIPTION
## Summary
- build dev container using custom Dockerfile that strips noisy bson warning
- avoid reinstalling codex-cli and suppress node.js warnings

## Testing
- `codex login` *(before: warning about padLevels)*
- `NODE_NO_WARNINGS=1 codex login`
- `jq '.' .devcontainer/devcontainer.json` *(fails: Invalid numeric literal at line 7)*

------
https://chatgpt.com/codex/tasks/task_e_6897ea0b70dc8320b3f169d5f6ed9596