### PR TITLE
fix: remove bson extension warning

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /home/node/.codex \
 
 # Install Codex CLI globally and strip noisy legacy warnings
 RUN npm install -g codex-cli \
-    && sed -i "/Failed to load c\+\+ bson extension/d" $(npm root -g)/codex-cli/node_modules/bson/ext/index.js
+    && sed -i '/Failed to load c++ bson extension/d' $(npm root -g)/codex-cli/node_modules/bson/ext/index.js
 
 # Create a startup script
 RUN echo '#!/bin/bash\n\


### PR DESCRIPTION
## Summary
- clean up bson module warning by adjusting Dockerfile sed command

## Testing
- `codex login >/tmp/codex_login.log && tail -n 20 /tmp/codex_login.log`


------
https://chatgpt.com/codex/tasks/task_e_6897f31882848320ba3fb8e3b072d1c7